### PR TITLE
Travis and Coveralls Integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,26 @@
+[run]
+source = {packagename}
+omit =
+   {packagename}/tests/travis_miniconda/*
+   {packagename}/data/*
+
+[report]
+exclude_lines =
+   # Have to re-enable the standard pragma
+   pragma: no cover
+
+   # Don't complain about packages we have installed
+   except ImportError
+
+   # Don't complain if tests don't hit assertions
+   raise AssertionError
+   raise NotImplementedError
+
+   # Don't complain about script hooks
+   def main\(.*\):
+
+   # Ignore branches that don't pertain to this version of Python
+   pragma: py{ignore_python_version}
+
+   # Don't complain about IPython completion helper
+   def _ipython_key_completions_

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@
 
 language : shell
 
+# Travis's build matrix will create runs for every single 
+# Sadly I couldn't find a way to nest environmental variables so
+# every combination is run.  If we really need to do that, we
+# can explicitly define a build matrix
+# https://docs.travis-ci.com/user/build-matrix/
 env:
-  - CONDA_PYTHON=3.5
-  - CONDA_PYTHON=3.6
-  - CONDA_PYTHON=3.7
-  - NUMPY_VERSION=1.13
-  - NUMPY_VERSION=1.16
-  - NETWORKX_VERSION=0.22
-  - NETWORKX_VERSION=0.23
+  - CONDA_PYTHON=3.5 NUMPY_VERSION=1.13 NETWORKX_VERSION=0.22
+  - CONDA_PYTHON=3.5 NUMPY_VERSION=1.16 NETWORKX_VERSION=0.23
+  - CONDA_PYTHON=3.6 NUMPY_VERSION=1.13 NETWORKX_VERSION=0.22
+  - CONDA_PYTHON=3.7 NUMPY_VERSION=1.13 NETWORKX_VERSION=0.22
 
 os:
   - linux
@@ -57,7 +59,11 @@ install:
   - pip install --user -r ./triplinker/tests/travis_miniconda/requirements.txt
 
 script:
-  - pytest -s -v --pyargs triplinker
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      export PATH=$PATH:";C:\Users\travis\AppData\Roaming\Python\Python35\Scripts;C:\Users\travis\AppData\Roaming\Python\Python36\Scripts;C:\Users\travis\AppData\Roaming\Python\Python37\Scripts";
+      echo "$PATH";
+    fi;
+  - python -m pytest -s -v triplinker
 
 after_success:
   - coveralls --rcfile='./coveragerc'

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,11 +59,10 @@ install:
   - pip install --user -r ./triplinker/tests/travis_miniconda/requirements.txt
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      export PATH=$PATH:";C:\Users\travis\AppData\Roaming\Python\Python35\Scripts;C:\Users\travis\AppData\Roaming\Python\Python36\Scripts;C:\Users\travis\AppData\Roaming\Python\Python37\Scripts";
-      echo "$PATH";
-    fi;
+  # Annoyingly for Windows systems pytest is installed in a folder not included
+  # in PATH - the solution is either to use the syntax below, or append to PATH
+  # (which is harder).
   - python -m pytest -s -v triplinker
 
 after_success:
-  - coveralls --rcfile='./coveragerc'
+  - coveralls --rcfile='.coveragerc'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+
+python:
+  - "3.5"
+  - "3.6"      # current detault Python on Travis CI
+  - "3.7"
+
+os:
+  - linux
+  - windows
+  - osx
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - pytest -s -v --pyargs triplinker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # From https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/.travis.yml
+# See alternative here: https://docs.travis-ci.com/user/languages/python/#running-python-tests-on-multiple-operating-systems
 
 language : shell
 
@@ -6,6 +7,10 @@ env:
   - CONDA_PYTHON=3.5
   - CONDA_PYTHON=3.6
   - CONDA_PYTHON=3.7
+  - NUMPY_VERSION=1.13
+  - NUMPY_VERSION=1.16
+  - NETWORKX_VERSION=0.22
+  - NETWORKX_VERSION=0.23
 
 os:
   - linux
@@ -47,9 +52,9 @@ install:
   - echo "Python $CONDA_PYTHON running on $TRAVIS_OS_NAME";
   - conda env create --name test-environment python=$CONDA_PYTHON --file=./triplinker/tests/travis_miniconda/env.${CONDA_PYTHON}.yml;
   - conda activate test-environment;
-  - pip install --upgrade pip;
+  - python -m pip install --upgrade pip;
   - conda --version ; python --version ; pip --version;
-  - pip install --user -r requirements.txt
+  - pip install --user -r ./triplinker/tests/travis_miniconda/requirements.txt
 
 script:
   - pytest -s -v --pyargs triplinker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,66 @@
-language: python
+# From https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/.travis.yml
 
-python:
-  - "3.5"
-  - "3.6"      # current detault Python on Travis CI
-  - "3.7"
+language : shell
+
+env:
+  - CONDA_PYTHON=3.5
+  - CONDA_PYTHON=3.6
+  - CONDA_PYTHON=3.7
 
 os:
   - linux
   - windows
   - osx
 
+before_install:
+  # set conda path info
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
+      MINICONDA_PATH=$HOME/miniconda;
+      MINICONDA_SUB_PATH=$MINICONDA_PATH/bin;
+    elif [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      MINICONDA_PATH=/c/tools/miniconda3/;
+      MINICONDA_PATH_WIN=`cygpath --windows $MINICONDA_PATH`;
+      MINICONDA_SUB_PATH=$MINICONDA_PATH/Scripts;
+    fi;
+  # obtain miniconda installer
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    elif  [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+    fi;
+
 install:
+  # install miniconda
+  after_success:
+    # If coveralls.io is set up for this package, uncomment the line below.
+    # The coveragerc file may be customized as needed for your package.
+    - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='baseband/tests/coveragerc'; fi
+  # pip and conda will also need OpenSSL for Windows
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
+      bash miniconda.sh -b -p $HOME/miniconda;
+    elif  [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      choco install openssl.light;
+      choco install miniconda3 --params="'/AddToPath:1 /D:$MINICONDA_PATH_WIN'";
+    fi;
+  - export PATH="$MINICONDA_PATH:$MINICONDA_SUB_PATH:$PATH";
+  # for conda version 4.4 or later
+  - source $MINICONDA_PATH/etc/profile.d/conda.sh;
+  - hash -r;
+  - conda config --set always_yes yes --set changeps1 no;
+  - conda update -q conda;
+  - echo "Python $CONDA_PYTHON running on $TRAVIS_OS_NAME";
+  - conda env create --name test-environment python=$CONDA_PYTHON --file=./triplinker/tests/travis_miniconda/env.${CONDA_PYTHON}.yml;
+  - conda activate test-environment;
+  - conda --version ; python --version ; pip --version;
   - pip install -r requirements.txt
+
+os:
+  - linux
+  - windows
+  - osx
 
 script:
   - pytest -s -v --pyargs triplinker
+
+after_success:
+  - coveralls --rcfile='./coveragerc'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ before_install:
 
 install:
   # install miniconda
-  after_success:
-    # If coveralls.io is set up for this package, uncomment the line below.
-    # The coveragerc file may be customized as needed for your package.
-    - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='baseband/tests/coveragerc'; fi
   # pip and conda will also need OpenSSL for Windows
   - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
       bash miniconda.sh -b -p $HOME/miniconda;
@@ -51,13 +47,9 @@ install:
   - echo "Python $CONDA_PYTHON running on $TRAVIS_OS_NAME";
   - conda env create --name test-environment python=$CONDA_PYTHON --file=./triplinker/tests/travis_miniconda/env.${CONDA_PYTHON}.yml;
   - conda activate test-environment;
+  - pip install --upgrade pip;
   - conda --version ; python --version ; pip --version;
-  - pip install -r requirements.txt
-
-os:
-  - linux
-  - windows
-  - osx
+  - pip install --user -r requirements.txt
 
 script:
   - pytest -s -v --pyargs triplinker

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ pytest -s -v --pyargs triplinker
 
 ## Project Status
 
+[![Build Status](https://travis-ci.org/CityofToronto/bdit_triplinker.svg?branch=master)](https://travis-ci.org/CityofToronto/bdit_triplinker)
+
+[![Coverage Status](https://coveralls.io/repos/github/CityofToronto/bdit_triplinker/badge.svg?branch=master)](https://coveralls.io/github/CityofToronto/bdit_triplinker?branch=master)
+
 ## License
 
 Triplinker is licensed under the GNU General Public License v3.0 - see the

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ eg. taxi companies).
 ### Dependencies
 
 ```
-networkx==2.2
-numpy>=1.14
-pandas>=0.23
-pytest>=3.8.0
-scikit-learn>=0.20
+networkx>=2.2
+numpy>=1.16
+pandas>=0.24
+tqdm>=4.32
+pytest>=5.0.0
+ortools>=7.1
 ```
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ numpy>=1.16
 pandas>=0.24
 tqdm>=4.32
 pytest>=5.0.0
+python-coveralls>=2.9
 ortools>=6.7
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ numpy>=1.16
 pandas>=0.24
 tqdm>=4.32
 pytest>=5.0.0
-ortools>=7.1
+ortools>=6.7
 ```
 
 ### Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ numpy>=1.15
 pandas>=0.23
 tqdm>=4.32
 pytest>=5.0.0
+python-coveralls>=2.9
 ortools>=6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 networkx>=2.2
-numpy>=1.16
-pandas>=0.24
+numpy>=1.15
+pandas>=0.23
 tqdm>=4.32
 pytest>=5.0.0
 ortools>=7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy>=1.15
 pandas>=0.23
 tqdm>=4.32
 pytest>=5.0.0
-ortools>=7.1
+ortools>=6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+networkx>=2.2
+numpy>=1.16
+pandas>=0.24
+tqdm>=4.32
+pytest>=5.0.0
+ortools>=7.1

--- a/triplinker/tests/travis_miniconda/env.3.5.yml
+++ b/triplinker/tests/travis_miniconda/env.3.5.yml
@@ -1,0 +1,8 @@
+# Based on https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/tests/environment.3.6.yml
+
+name: travis_anaconda_jupyter
+channels:
+- defaults
+
+dependencies:
+- python=3.5

--- a/triplinker/tests/travis_miniconda/env.3.6.yml
+++ b/triplinker/tests/travis_miniconda/env.3.6.yml
@@ -1,0 +1,8 @@
+# Based on https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/tests/environment.3.6.yml
+
+name: travis_anaconda_jupyter
+channels:
+- defaults
+
+dependencies:
+- python=3.6

--- a/triplinker/tests/travis_miniconda/env.3.7.yml
+++ b/triplinker/tests/travis_miniconda/env.3.7.yml
@@ -1,0 +1,8 @@
+# Based on https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/tests/environment.3.6.yml
+
+name: travis_anaconda_jupyter
+channels:
+- defaults
+
+dependencies:
+- python=3.7

--- a/triplinker/tests/travis_miniconda/requirements.txt
+++ b/triplinker/tests/travis_miniconda/requirements.txt
@@ -3,4 +3,5 @@ numpy>=${NUMPY_VERSION}
 pandas>=0.23
 tqdm>=4.32
 pytest>=5.0.0
+coveralls>=1.8
 ortools>=6.7

--- a/triplinker/tests/travis_miniconda/requirements.txt
+++ b/triplinker/tests/travis_miniconda/requirements.txt
@@ -1,0 +1,6 @@
+networkx>=${NETWORKX_VERSION}
+numpy>=${NUMPY_VERSION}
+pandas>=0.23
+tqdm>=4.32
+pytest>=5.0.0
+ortools>=6.7


### PR DESCRIPTION
Integrated package with [Travis CI](https://travis-ci.org/CityofToronto/bdit_triplinker) and [Coveralls.io](https://coveralls.io/github/CityofToronto/bdit_triplinker).  Added flags and build environment specifications (under `tests/travis_miniconda`) to run the test suite in Linux, Windows and OSX Python 3.5/3.6/3.7 Miniconda environments (following [this example](https://github.com/kangwonlee/travis-yml-conda-posix-nt/blob/master/tests/environment.3.6.yml)).  Added `requirements.txt`, and a copy that uses environmental variables to set the package version.