### PR TITLE
Fix Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,4 +65,4 @@ script:
   - python -m pytest -s -v triplinker
 
 after_success:
-  - coveralls --rcfile='.coveragerc'
+  - coveralls --verbose --rcfile='.coveragerc'

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,10 @@ install:
 script:
   # Annoyingly for Windows systems pytest is installed in a folder not included
   # in PATH - the solution is either to use the syntax below, or append to PATH
-  # (which is harder).
-  - python -m pytest -s -v triplinker
+  # (which is harder).  "coverage" is to run coverage on top of pytest, as noted
+  # in https://coveralls-python.readthedocs.io/en/latest/usage/index.html.
+  #- python -m pytest -s -v triplinker
+  - python -m coverage run --source triplinker -m py.test
 
 after_success:
   - coveralls --verbose --rcfile='.coveragerc'

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,5 @@ script:
   - python -m coverage run --source triplinker -m py.test
 
 after_success:
-  - coveralls --verbose --rcfile='.coveragerc'
+  # Can turn on --verbose for troubleshooting.
+  - coveralls --rcfile='.coveragerc'


### PR DESCRIPTION
We weren't actually creating a coverage report to send to coveralls.  This fix repairs that by calling `coverage` within the Travis CI run script.